### PR TITLE
Automatically get all the DestinationRender implementations from koin

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ class DemoDrawerViewModel(
 
 }
 ```
+
 **2-** Once your custom `DrawerViewModel` is defined, then we are going to do the custom `DestinationRender`, in this case lets do a `RootDestinationRender` for simplicity.
 Notice bellow how the integration with `Koin` allows us to inject the ViewModel instance and scope it to the nearest NavBackStackEntry.
 
@@ -134,35 +135,25 @@ class DemoDrawerRootDestinationRender : RootDestinationRender {
 }
 
 ```
-**3-** The last step is registering our implementation in the `DestinationRendersDirectory`. For that, in your implementation of `RootGraphInitializer`, place a code similar to this:
+
+**3-** The last step is providing a Koin module that creates the instances of your classes
 ```kotlin
-class DemoRootGraphInitializer : RootGraphInitializer {
+internal val drawerRootDestinationModule = module {
 
-    override fun shouldShowLoader(): Boolean {
-        return true
-    }
+  factoryOf(::DemoDrawerDataSource)
+  factory<DrawerStatePresenterDefault> {
+    DrawerComponentDefaults.createDrawerStatePresenter()
+  }
 
-    override suspend fun initialize(koinComponent: KoinComponent): MacaoResult<RootDestinationRender> {
-        
-        // ... Do your initialization stuff and when done, then register all the DestinationRenders in the registry. 
-        
-        // Register all the Destin ation Renders from all the plugins in the DestinationRendersRegistry
-        // TODO: This can be done using koin.getAll()
-        koinComponent
-          .get<DestinationRendersRegistry>()
-          .apply {
-            addRoot(DemoDrawerRootDestinationRender())
-            add(SimpleScreenDestinationRender())
-            add(SimpleScreen1DestinationRender())
-          }
-      
-        val rootDestinationInfo = serverUiRemoteService.getRootDestinationInfo()
-      
-        return MacaoResult.Success(rootDestinationInfo)
-    }
+  // DrawerViewModel
+  viewModelOf(::DemoDrawerViewModel)
+
+  factory { DemoDrawerRootDestinationRender() } bind (RootDestinationRender::class)
 }
-
 ```
+The `bind (RootDestinationRender::class)` is a must for Koin to include it in a list of all
+DestinationRender implementations. We then get that list and register all the renders in the
+`DestinationRendersRegistry`.
 
 **4-** And that was it. Above steps will give you something like shown in the gif image bellow:
 

--- a/composeApp/src/commonMain/kotlin/com.macaosoftware.component.navigationcompose.demo/di/DrawerViewModelsModule.kt
+++ b/composeApp/src/commonMain/kotlin/com.macaosoftware.component.navigationcompose.demo/di/DrawerViewModelsModule.kt
@@ -1,13 +1,14 @@
 package com.macaosoftware.component.navigationcompose.demo.di
 
+import com.macaosoftware.component.core.RootDestinationRender
 import com.macaosoftware.component.drawer.DrawerComponentDefaults
 import com.macaosoftware.component.drawer.DrawerStatePresenterDefault
 import com.macaosoftware.component.navigationcompose.demo.marketplace.navigators.drawer.DemoDrawerDataSource
+import com.macaosoftware.component.navigationcompose.demo.marketplace.navigators.drawer.DemoDrawerRootDestinationRender
 import com.macaosoftware.component.navigationcompose.demo.marketplace.navigators.drawer.DemoDrawerViewModel
-import org.koin.compose.viewmodel.dsl.viewModel
 import org.koin.compose.viewmodel.dsl.viewModelOf
 import org.koin.core.module.dsl.factoryOf
-import org.koin.core.parameter.ParametersHolder
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 internal val drawerViewModelsModule = module {
@@ -27,4 +28,6 @@ internal val drawerViewModelsModule = module {
             destinationRendersRegistry = get()
         )
     }*/
+
+    factory { DemoDrawerRootDestinationRender() } bind (RootDestinationRender::class)
 }

--- a/composeApp/src/commonMain/kotlin/com.macaosoftware.component.navigationcompose.demo/di/MiscScreensViewModelsModule.kt
+++ b/composeApp/src/commonMain/kotlin/com.macaosoftware.component.navigationcompose.demo/di/MiscScreensViewModelsModule.kt
@@ -1,7 +1,11 @@
 package com.macaosoftware.component.navigationcompose.demo.di
 
-import com.macaosoftware.component.navigationcompose.demo.marketplace.misc.simplescreen1.SimpleScreen1ViewModel
+import com.macaosoftware.component.core.DestinationRender
+import com.macaosoftware.component.navigationcompose.demo.marketplace.misc.simplescreen.SimpleScreenDestinationRender
 import com.macaosoftware.component.navigationcompose.demo.marketplace.misc.simplescreen.SimpleScreenViewModel
+import com.macaosoftware.component.navigationcompose.demo.marketplace.misc.simplescreen1.SimpleScreen1DestinationRender
+import com.macaosoftware.component.navigationcompose.demo.marketplace.misc.simplescreen1.SimpleScreen1ViewModel
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 internal val miscScreensViewModelsModule = module {
@@ -20,4 +24,7 @@ internal val miscScreensViewModelsModule = module {
             resultHandler = params.get()
         )
     }
+
+    factory { SimpleScreenDestinationRender() } bind (DestinationRender::class)
+    factory { SimpleScreen1DestinationRender() } bind (DestinationRender::class)
 }

--- a/composeApp/src/commonMain/kotlin/com.macaosoftware.component.navigationcompose.demo/startup/initializers/DemoRootGraphInitializer.kt
+++ b/composeApp/src/commonMain/kotlin/com.macaosoftware.component.navigationcompose.demo/startup/initializers/DemoRootGraphInitializer.kt
@@ -2,10 +2,6 @@ package com.macaosoftware.component.navigationcompose.demo.startup.initializers
 
 import com.macaosoftware.app.startup.initializers.RootGraphInitializer
 import com.macaosoftware.component.core.DestinationInfo
-import com.macaosoftware.component.core.DestinationRendersRegistry
-import com.macaosoftware.component.navigationcompose.demo.marketplace.misc.simplescreen.SimpleScreenDestinationRender
-import com.macaosoftware.component.navigationcompose.demo.marketplace.misc.simplescreen1.SimpleScreen1DestinationRender
-import com.macaosoftware.component.navigationcompose.demo.marketplace.navigators.drawer.DemoDrawerRootDestinationRender
 import com.macaosoftware.component.navigationcompose.demo.serverui.data.ServerUiRemoteService
 import com.macaosoftware.util.MacaoResult
 import org.koin.core.component.KoinComponent
@@ -20,24 +16,7 @@ class DemoRootGraphInitializer : RootGraphInitializer {
     override suspend fun initialize(koinComponent: KoinComponent): MacaoResult<DestinationInfo> {
 
         val serverUiRemoteService = koinComponent.get<ServerUiRemoteService>()
-
-        // val rootDestinationJson = serverUiRemoteService.getRootJsonResilience()
-
-        // val rootDestinationJson = serverUiRemoteService.getRemoteRootComponent("123")
-        //    ?: serverUiRemoteService.getRootJsonResilience()
-
-        // Migration
-
         val rootDestinationInfo = serverUiRemoteService.getRootDestinationInfo()
-
-        // TODO: This can be done using koin.getAll()
-        val destinationRendersRegistry = koinComponent
-            .get<DestinationRendersRegistry>()
-            .apply {
-                addRoot(DemoDrawerRootDestinationRender())
-                add(SimpleScreenDestinationRender())
-                add(SimpleScreen1DestinationRender())
-            }
 
         return MacaoResult.Success(rootDestinationInfo)
     }


### PR DESCRIPTION
Automatically get all the DestinationRender implementations from koin getAll() and register them in the DestinationRenderRegistry.