### PR TITLE
Move coroutine dispatchers container initialization to expect-actual

### DIFF
--- a/composeApp/src/commonMain/kotlin/com.macaosoftware.component.navigationcompose.demo/startup/initializers/CommonKoinModulesInitializer.kt
+++ b/composeApp/src/commonMain/kotlin/com.macaosoftware.component.navigationcompose.demo/startup/initializers/CommonKoinModulesInitializer.kt
@@ -7,13 +7,13 @@ import com.macaosoftware.component.navigationcompose.demo.marketplace.navigators
 import com.macaosoftware.component.navigationcompose.demo.marketplace.notfound.di.destinationNotFoundModule
 import com.macaosoftware.component.navigationcompose.demo.serverui.di.serverUiModule
 import com.macaosoftware.component.navigationcompose.demo.system.di.commonKoinModule
-import com.macaosoftware.plugin.CoroutineDispatchers
+import com.macaosoftware.plugin.getCoroutineDispatchers
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.koin.core.module.Module
 
 abstract class CommonKoinModulesInitializer(
-    private val ioDispatcher: CoroutineDispatcher = CoroutineDispatchers.Default.io
+    private val ioDispatcher: CoroutineDispatcher = getCoroutineDispatchers().io
 ) : KoinModulesInitializer {
 
     override suspend fun initialize(): List<Module> = withContext(ioDispatcher) {

--- a/macao-jetpack-navigation/src/androidMain/kotlin/com/macaosoftware/plugin/CoroutineDispatchers.android.kt
+++ b/macao-jetpack-navigation/src/androidMain/kotlin/com/macaosoftware/plugin/CoroutineDispatchers.android.kt
@@ -1,0 +1,9 @@
+package com.macaosoftware.plugin
+
+import kotlinx.coroutines.Dispatchers
+
+actual fun getCoroutineDispatchers() = CoroutineDispatchers(
+    main = Dispatchers.Main,
+    default = Dispatchers.Default,
+    io = Dispatchers.IO
+)

--- a/macao-jetpack-navigation/src/commonMain/kotlin/com/macaosoftware/app/MacaoApplication.kt
+++ b/macao-jetpack-navigation/src/commonMain/kotlin/com/macaosoftware/app/MacaoApplication.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.compose.LifecycleStartEffect
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import org.koin.compose.KoinIsolatedContext
 
@@ -21,8 +22,11 @@ private const val ErrorNullViewModelStoreOwner = """
 fun MacaoApplication(
     applicationState: MacaoApplicationState
 ) {
-
-    LifecycleStartEffect(key1 = applicationState) {
+    LocalLifecycleOwner.current!!
+    LifecycleStartEffect(
+        key1 = applicationState,
+        lifecycleOwner = LocalLifecycleOwner.current
+    ) {
         applicationState.start()
         onStopOrDispose {
             // no-op

--- a/macao-jetpack-navigation/src/commonMain/kotlin/com/macaosoftware/app/MacaoApplicationState.kt
+++ b/macao-jetpack-navigation/src/commonMain/kotlin/com/macaosoftware/app/MacaoApplicationState.kt
@@ -13,6 +13,7 @@ import com.macaosoftware.component.core.DestinationRendersRegistry
 import com.macaosoftware.component.core.RootDestinationRender
 import com.macaosoftware.component.drawer.DrawerResultAdapter
 import com.macaosoftware.plugin.CoroutineDispatchers
+import com.macaosoftware.plugin.getCoroutineDispatchers
 import com.macaosoftware.util.MacaoError
 import com.macaosoftware.util.MacaoResult
 import kotlinx.coroutines.CoroutineScope
@@ -25,7 +26,7 @@ class MacaoApplicationState(
     private val koinModulesInitializer: KoinModulesInitializer,
     private val startupTaskRunner: StartupTaskRunner,
     private val rootGraphInitializer: RootGraphInitializer,
-    private val dispatchers: CoroutineDispatchers = CoroutineDispatchers.Default
+    private val dispatchers: CoroutineDispatchers = getCoroutineDispatchers()
 ) {
 
     internal var startupStage = mutableStateOf<StartupStage>(JustCreated)

--- a/macao-jetpack-navigation/src/commonMain/kotlin/com/macaosoftware/plugin/CoroutineDispatchers.kt
+++ b/macao-jetpack-navigation/src/commonMain/kotlin/com/macaosoftware/plugin/CoroutineDispatchers.kt
@@ -3,16 +3,10 @@ package com.macaosoftware.plugin
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
-class CoroutineDispatchers(
+data class CoroutineDispatchers(
     val main: CoroutineDispatcher,
     val default: CoroutineDispatcher,
     val io: CoroutineDispatcher
-) {
-    companion object {
-        val Default = CoroutineDispatchers(
-            main = Dispatchers.Main,
-            default = Dispatchers.Default,
-            io = Dispatchers.Unconfined
-        )
-    }
-}
+)
+
+expect fun getCoroutineDispatchers(): CoroutineDispatchers

--- a/macao-jetpack-navigation/src/iosMain/kotlin/com/macaosoftware/plugin/CoroutineDispatchers.ios.kt
+++ b/macao-jetpack-navigation/src/iosMain/kotlin/com/macaosoftware/plugin/CoroutineDispatchers.ios.kt
@@ -1,0 +1,10 @@
+package com.macaosoftware.plugin
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+
+actual fun getCoroutineDispatchers() = CoroutineDispatchers(
+    main = Dispatchers.Main,
+    default = Dispatchers.Default,
+    io = Dispatchers.IO
+)

--- a/macao-jetpack-navigation/src/jsMain/kotlin/com/macaosoftware/plugin/CoroutineDispatchers.js.kt
+++ b/macao-jetpack-navigation/src/jsMain/kotlin/com/macaosoftware/plugin/CoroutineDispatchers.js.kt
@@ -1,0 +1,9 @@
+package com.macaosoftware.plugin
+
+import kotlinx.coroutines.Dispatchers
+
+actual fun getCoroutineDispatchers() = CoroutineDispatchers(
+    main = Dispatchers.Main,
+    default = Dispatchers.Default,
+    io = Dispatchers.Unconfined
+)

--- a/macao-jetpack-navigation/src/jvmMain/kotlin/com/macaosoftware/plugin/CoroutineDispatchers.jvm.kt
+++ b/macao-jetpack-navigation/src/jvmMain/kotlin/com/macaosoftware/plugin/CoroutineDispatchers.jvm.kt
@@ -1,0 +1,9 @@
+package com.macaosoftware.plugin
+
+import kotlinx.coroutines.Dispatchers
+
+actual fun getCoroutineDispatchers() = CoroutineDispatchers(
+    main = Dispatchers.Main,
+    default = Dispatchers.Default,
+    io = Dispatchers.IO
+)


### PR DESCRIPTION
Move coroutine dispatchers container initialization to expect-actual per platform. To use dispatcher IO accordingly.